### PR TITLE
Remove unnecessary prefix.

### DIFF
--- a/tabgeo/core.py
+++ b/tabgeo/core.py
@@ -38,7 +38,7 @@ def tabgeo_bs(data_array, ip, step):
         if step:
             (u['offset'], u['ip'], u['cc_id']) = unpack(">IBB", b'\x00'+data_array[mid])
         else:
-            (u['ip'], u['cc_id']) = unpack(">BB", b'\x00'+data_array[mid])
+            (u['ip'], u['cc_id']) = unpack(">BB", data_array[mid])
         if u['ip'] == ip:
             return u
         if end - start < 0:


### PR DESCRIPTION
Fixes struct.error: unpack requires a string argument of length 2.
You can use 5.135.54.163 to test.
